### PR TITLE
fix: adjust nginx config 502 and 504

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,9 @@ services:
     build: ./blog
     container_name: blog_c
     stdin_open: true
-    volumes:
-      - ./blog:/app
-      - ./app/node_modules
-      - ./app/.next
   api:
     build: ./api
     container_name: api_c
-    volumes:
-      - ./api:/app
-      - ./app/node_modules
   nginx:
     build: ./nginx
     container_name: nginx_c

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,5 @@
 server {
   listen 80;
-  server_name host.docker.internal;
 
   root /var/www/html;
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,9 +1,10 @@
 server {
   listen 80;
+  server_name host.docker.internal;
 
   root /var/www/html;
 
-  proxy_read_timeout 5;
+  proxy_read_timeout 6000;
   proxy_connect_timeout 5;
   proxy_send_timeout 5;
 
@@ -12,6 +13,7 @@ server {
   }
 
   location /api {
+    rewrite ^/api(.*)$ $1 break;
     proxy_pass http://api:9000;
   }
 }


### PR DESCRIPTION
- [X] Fix api 502 by rewrite prefix `/api` in location /api block, so that the request received by backend without `/api` prefix
- [X] Increse `proxy_read_timeout` by 6000 ms, because the backend response take time too long, (referenced by setTimeout inside api dir)